### PR TITLE
Complete support for TrueNAS SCALE 25.10

### DIFF
--- a/install_ugreen_leds_controller.sh
+++ b/install_ugreen_leds_controller.sh
@@ -332,6 +332,8 @@ elif [[ "$TRUENAS_SERIES" == "24.04" ]]; then
     TRUENAS_NAME="TrueNAS-SCALE-Dragonfish"
 elif [[ "$TRUENAS_SERIES" == "25.04" ]]; then
     TRUENAS_NAME="TrueNAS-SCALE-Fangtooth"
+elif [[ "$TRUENAS_SERIES" == "25.10" ]]; then
+    TRUENAS_NAME="TrueNAS-SCALE-Goldeye"
 else
     echo "Unsupported TrueNAS SCALE version series: ${TRUENAS_SERIES}."
     echo "Please build the kernel module manually."


### PR DESCRIPTION
The support for TrueNAS SCALE Goldeye was partially implemented.

The variable `KMOD_URLS` already covered the Goldeye url, though the condition for downloading the kernel modul didn't cover version 25.10 yet. This pr adds the missing bit..  