### PR TITLE
fix: force decimal base in patch version arithmetic to avoid octal errors

### DIFF
--- a/install_ugreen_leds_controller.sh
+++ b/install_ugreen_leds_controller.sh
@@ -637,7 +637,7 @@ resolve_module_url() {
     candidates=("$running_version")
 
     if [[ "$version_patch_str" =~ ^[0-9]+$ ]]; then
-        version_patch=$(( version_patch_str ))
+        version_patch=$(( 10#$version_patch_str ))
         # For 4-part versions (e.g. 25.04.0.1), also try the 3-part form
         local three_part="${version_major}.${version_patch}"
         if [ "$three_part" != "$running_version" ]; then


### PR DESCRIPTION
Bash interprets numeric strings with leading zeros as octal in $(()), so version components like '08' or '09' would cause an invalid octal error. Using 10# forces decimal interpretation regardless of leading zeros.