### PR TITLE
docs: add DXP3800 Plus and DXP6800 Pro to compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This installer has been confirmed working on the following models. For general m
 | UGREEN DXP4800 | Tested with TrueNAS SCALE 25.04.2.5, script v1.0 | [#6](https://github.com/0x556c79/install_ugreen_leds_controller/issues/6) |
 | UGREEN DXP2800 | | [#12](https://github.com/0x556c79/install_ugreen_leds_controller/pull/12) |
 | UGREEN DXP3800 Plus | Tested with TrueNAS SCALE 25.10.3 | [#18](https://github.com/0x556c79/install_ugreen_leds_controller/issues/18) |
-| UGREEN NASync DXP6800 Pro | Tested with TrueNAS Scale 25.10.3 | [#17](https://github.com/0x556c79/install_ugreen_leds_controller/issues/17) |
+| UGREEN DXP6800 Pro | Tested with TrueNAS SCALE 25.10.3 | [#17](https://github.com/0x556c79/install_ugreen_leds_controller/issues/17) |
 
 If you've confirmed the script works on another model, feel free to open an issue or pull request!
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This installer has been confirmed working on the following models. For general m
 | UGREEN DXP8800 Plus | Developed & tested on this model | — |
 | UGREEN DXP4800 | Tested with TrueNAS SCALE 25.04.2.5, script v1.0 | [#6](https://github.com/0x556c79/install_ugreen_leds_controller/issues/6) |
 | UGREEN DXP2800 | | [#12](https://github.com/0x556c79/install_ugreen_leds_controller/pull/12) |
-| UGREEN NASync DXP3800 Plus | Tested with TrueNAS 25.10.3 | [#18](https://github.com/0x556c79/install_ugreen_leds_controller/issues/18) |
+| UGREEN DXP3800 Plus | Tested with TrueNAS SCALE 25.10.3 | [#18](https://github.com/0x556c79/install_ugreen_leds_controller/issues/18) |
 | UGREEN NASync DXP6800 Pro | Tested with TrueNAS Scale 25.10.3 | [#17](https://github.com/0x556c79/install_ugreen_leds_controller/issues/17) |
 
 If you've confirmed the script works on another model, feel free to open an issue or pull request!

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This installer has been confirmed working on the following models. For general m
 | UGREEN DXP8800 Plus | Developed & tested on this model | — |
 | UGREEN DXP4800 | Tested with TrueNAS SCALE 25.04.2.5, script v1.0 | [#6](https://github.com/0x556c79/install_ugreen_leds_controller/issues/6) |
 | UGREEN DXP2800 | | [#12](https://github.com/0x556c79/install_ugreen_leds_controller/pull/12) |
+| UGREEN NASync DXP3800 Plus | Tested with TrueNAS 25.10.3 | [#18](https://github.com/0x556c79/install_ugreen_leds_controller/issues/18) |
+| UGREEN NASync DXP6800 Pro | Tested with TrueNAS Scale 25.10.3 | [#17](https://github.com/0x556c79/install_ugreen_leds_controller/issues/17) |
 
 If you've confirmed the script works on another model, feel free to open an issue or pull request!
 


### PR DESCRIPTION
Closes #17 and #18.

Issue #17 (DXP6800 Pro, TrueNAS Scale 25.10.3) — added to compatibility table, commented, closed

Issue #18 (DXP3800 Plus, TrueNAS 25.10.3) — added to compatibility table, commented, closed
The README's compatibility table now lists 5 confirmed models.